### PR TITLE
Fix some byte compile warnings

### DIFF
--- a/run-command-recipes-hashtables.el
+++ b/run-command-recipes-hashtables.el
@@ -1,11 +1,11 @@
-;;; run-command-recipes-hashtables --- Operations on `hashtable` -*- lexical-binding: t; -*-
+;;; run-command-recipes-hashtables.el --- Operations on `hashtable` -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2022 Free Software Foundation, Inc.
 
 ;; Author: semenInRussia <hrams205@gmail.com>
 ;; Version: 0.0.1
-;; Packages-Requires: ((dash "2.18.0")
-;;                     (s     "1.12.0"))
+;; Package-Requires: ((dash "2.18.0")
+;;                    (s     "1.12.0"))
 
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/run-command-recipes-haskell.el
+++ b/run-command-recipes-haskell.el
@@ -30,6 +30,7 @@
 
 (require 'run-command)
 (require 'run-command-recipes-files)
+(require 'f)
 
 (defun run-command-recipe-haskell ()
     "`run-command''s recipe for `haskell`."

--- a/run-command-recipes-latex.el
+++ b/run-command-recipes-latex.el
@@ -1,14 +1,14 @@
-;;; run-command-recipes-latex --- Recipe of `run-command' for `latex` -*- lexical-binding: t; -*-
+;;; run-command-recipes-latex.el --- Recipe of `run-command' for `latex` -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2022 Free Software Foundation, Inc.
 
 ;; Author: semenInRussia <hrams205@gmail.com>
 ;; Version: 0.0.1
-;; Packages-Requires: ((dash        "2.18.0")
-;;                     (s           "1.12.0")
-;;                     (f           "0.20.0")
-;;                     (run-command "0.1.0")
-;;                     (emacs       "27.1"))
+;; Package-Requires: ((dash        "2.18.0")
+;;                    (s           "1.12.0")
+;;                    (f           "0.20.0")
+;;                    (run-command "0.1.0")
+;;                    (emacs       "27.1"))
 
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/run-command-recipes-pandoc.el
+++ b/run-command-recipes-pandoc.el
@@ -1,14 +1,14 @@
-;;; run-command-recipes-pandoc --- Recipe of `run-command' for `pandoc` -*- lexical-binding: t; -*-
+;;; run-command-recipes-pandoc.el --- Recipe of `run-command' for `pandoc` -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2022 Free Software Foundation, Inc.
 
 ;; Author: semenInRussia <hrams205@gmail.com>
 ;; Version: 0.0.1
-;; Packages-Requires: ((dash        "2.18.0")
-;;                     (s           "1.12.0")
-;;                     (f           "0.20.0")
-;;                     (run-command "0.1.0")
-;;                     (emacs       "27.1"))
+;; Package-Requires: ((dash        "2.18.0")
+;;                    (s           "1.12.0")
+;;                    (f           "0.20.0")
+;;                    (run-command "0.1.0")
+;;                    (emacs       "27.1"))
 
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/run-command-recipes.el
+++ b/run-command-recipes.el
@@ -1,14 +1,14 @@
-;;; run-command-recipes --- This is collection of recipes to `run-command' -*- lexical-binding: t; -*-
+;;; run-command-recipes.el --- This is collection of recipes to `run-command' -*- lexical-binding: t; -*-
 
 ;; Copyright (C) 2022 Free Software Foundation, Inc.
 
 ;; Author: semenInRussia <hrams205@gmail.com>
 ;; Version: 0.0.1
-;; Packages-Requires: ((dash        "2.18.0")
-;;                     (s           "1.12.0")
-;;                     (f           "0.20.0")
-;;                     (run-command "0.1.0")
-;;                     (emacs       "27.1"))
+;; Package-Requires: ((dash        "2.18.0")
+;;                    (s           "1.12.0")
+;;                    (f           "0.20.0")
+;;                    (run-command "0.1.0")
+;;                    (emacs       "27.1"))
 
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by

--- a/run-command-recipes.el
+++ b/run-command-recipes.el
@@ -28,6 +28,8 @@
 
 ;;; Code:
 (require 'run-command)
+(require 's)
+(require 'dash)
 
 (add-to-list 'run-command-experiments
              'run-command-experiment-lisp-commands)
@@ -54,7 +56,7 @@
 
 (defmacro run-command-recipes-useq-one (recipe)
     "Use RECIPE for `run-command' from `run-command-recipes' with quote RECIPE."
-    (run-command-recipes-use-one ',recipe))
+    `(run-command-recipes-use-one ',recipe))
 
 
 (defun run-command-recipes-use-one (recipe)


### PR DESCRIPTION
```
In run-command-recipes-use:
run-command-recipes.el:51:38: Warning: reference to free variable ‘it’

In run-command-recipes-useq-one:
run-command-recipes.el:55:41: Warning: Unused lexical argument `recipe'

In end of data:
run-command-recipes.el:66:31: Warning: the function ‘s-concat’ is not known to
    be defined.
run-command-recipes.el:50:6: Warning: the function ‘--each’ is not known to be
    defined.

In end of data:
run-command-recipes-haskell.el:38:24: Warning: the function ‘f-base’ is not
    known to be defined.
```